### PR TITLE
fix: correctly set config.json permissions

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -201,7 +201,7 @@ func loadConfig() (*Config, error) {
 			return nil, err
 		}
 
-		err = os.WriteFile(file, data, 555)
+		err = os.WriteFile(file, data, 0555)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -201,7 +201,7 @@ func loadConfig() (*Config, error) {
 			return nil, err
 		}
 
-		err = os.WriteFile(file, data, 0555)
+		err = os.WriteFile(file, data, 0644) // rw-r--r--
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
correctly sets `config.json`'s permissions: adds forgotten leading zero in the `FileMode` argument